### PR TITLE
first attempt

### DIFF
--- a/thorn/django/migrations/0001_initial.py
+++ b/thorn/django/migrations/0001_initial.py
@@ -62,6 +62,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='subscriber',
-            unique_together=set([('url', 'event')]),
+            unique_together=set([('event', 'url')]),
         ),
     ]


### PR DESCRIPTION
Seems to solve an issue with migration when on Django v2.1 where eliminating the unique_together constraint is not possible.

This may just be a bug within Django, but the PR solves our problem immediately